### PR TITLE
feat: settings export/import with native file dialogs and Win32 file watcher

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,16 +6,18 @@
       "name": "bloom",
       "dependencies": {
         "@crabnebula/tauri-plugin-drag": "^2.1.0",
-        "@tauri-apps/api": "^2",
+        "@tauri-apps/api": "~2.11.1",
         "@tauri-apps/plugin-autostart": "^2.5.1",
+        "@tauri-apps/plugin-dialog": "^2.7.2",
         "@tauri-apps/plugin-opener": "^2",
         "@tauri-apps/plugin-updater": "^2.10.1",
         "framer-motion": "^12.38.0",
+        "lucide-react": "^1.28.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
       },
       "devDependencies": {
-        "@tauri-apps/cli": "^2",
+        "@tauri-apps/cli": "~2.11",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^4.6.0",
@@ -182,33 +184,35 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.59.0", "", { "os": "win32", "cpu": "x64" }, "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA=="],
 
-    "@tauri-apps/api": ["@tauri-apps/api@2.10.1", "", {}, "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw=="],
+    "@tauri-apps/api": ["@tauri-apps/api@2.11.1", "", {}, "sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA=="],
 
-    "@tauri-apps/cli": ["@tauri-apps/cli@2.10.1", "", { "optionalDependencies": { "@tauri-apps/cli-darwin-arm64": "2.10.1", "@tauri-apps/cli-darwin-x64": "2.10.1", "@tauri-apps/cli-linux-arm-gnueabihf": "2.10.1", "@tauri-apps/cli-linux-arm64-gnu": "2.10.1", "@tauri-apps/cli-linux-arm64-musl": "2.10.1", "@tauri-apps/cli-linux-riscv64-gnu": "2.10.1", "@tauri-apps/cli-linux-x64-gnu": "2.10.1", "@tauri-apps/cli-linux-x64-musl": "2.10.1", "@tauri-apps/cli-win32-arm64-msvc": "2.10.1", "@tauri-apps/cli-win32-ia32-msvc": "2.10.1", "@tauri-apps/cli-win32-x64-msvc": "2.10.1" }, "bin": { "tauri": "tauri.js" } }, "sha512-jQNGF/5quwORdZSSLtTluyKQ+o6SMa/AUICfhf4egCGFdMHqWssApVgYSbg+jmrZoc8e1DscNvjTnXtlHLS11g=="],
+    "@tauri-apps/cli": ["@tauri-apps/cli@2.11.4", "", { "optionalDependencies": { "@tauri-apps/cli-darwin-arm64": "2.11.4", "@tauri-apps/cli-darwin-x64": "2.11.4", "@tauri-apps/cli-linux-arm-gnueabihf": "2.11.4", "@tauri-apps/cli-linux-arm64-gnu": "2.11.4", "@tauri-apps/cli-linux-arm64-musl": "2.11.4", "@tauri-apps/cli-linux-riscv64-gnu": "2.11.4", "@tauri-apps/cli-linux-x64-gnu": "2.11.4", "@tauri-apps/cli-linux-x64-musl": "2.11.4", "@tauri-apps/cli-win32-arm64-msvc": "2.11.4", "@tauri-apps/cli-win32-ia32-msvc": "2.11.4", "@tauri-apps/cli-win32-x64-msvc": "2.11.4" }, "bin": { "tauri": "tauri.js" } }, "sha512-R8xGtMpwyetawSqm9kYOuMmEqkhUbvcUy8n0aNXIxollKBLESUu5f4Fx+64hgASYm1H+jSWq6jCW6zqTnH6hqQ=="],
 
-    "@tauri-apps/cli-darwin-arm64": ["@tauri-apps/cli-darwin-arm64@2.10.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Z2OjCXiZ+fbYZy7PmP3WRnOpM9+Fy+oonKDEmUE6MwN4IGaYqgceTjwHucc/kEEYZos5GICve35f7ZiizgqEnQ=="],
+    "@tauri-apps/cli-darwin-arm64": ["@tauri-apps/cli-darwin-arm64@2.11.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-1ryOF3ZhpZ/nemHV5zVwBQBz9jDGKmKPvWPADOhc83ig0P4bMc2iER4NbC6r9sjeIZ6RVQ4g3RZIYvezhcl4TQ=="],
 
-    "@tauri-apps/cli-darwin-x64": ["@tauri-apps/cli-darwin-x64@2.10.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-V/irQVvjPMGOTQqNj55PnQPVuH4VJP8vZCN7ajnj+ZS8Kom1tEM2hR3qbbIRoS3dBKs5mbG8yg1WC+97dq17Pw=="],
+    "@tauri-apps/cli-darwin-x64": ["@tauri-apps/cli-darwin-x64@2.11.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-uFsGQAAfuyz1k/yGLmkWfkBlgKAqZfxqlHmLWx81QU27RJWfmbNHCIq8T8w1e+VClleIuZUjpHWfoE4E3DLo3A=="],
 
-    "@tauri-apps/cli-linux-arm-gnueabihf": ["@tauri-apps/cli-linux-arm-gnueabihf@2.10.1", "", { "os": "linux", "cpu": "arm" }, "sha512-Hyzwsb4VnCWKGfTw+wSt15Z2pLw2f0JdFBfq2vHBOBhvg7oi6uhKiF87hmbXOBXUZaGkyRDkCHsdzJcIfoJC2w=="],
+    "@tauri-apps/cli-linux-arm-gnueabihf": ["@tauri-apps/cli-linux-arm-gnueabihf@2.11.4", "", { "os": "linux", "cpu": "arm" }, "sha512-IaHZn5CdBL21oUmjiVOS1ctw6Ip1O0pjp70FwOWmYz1myWe0SY96ZIj2FYf7pT0m8bI2h/hrs5ZbEXXh44/MkQ=="],
 
-    "@tauri-apps/cli-linux-arm64-gnu": ["@tauri-apps/cli-linux-arm64-gnu@2.10.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-OyOYs2t5GkBIvyWjA1+h4CZxTcdz1OZPCWAPz5DYEfB0cnWHERTnQ/SLayQzncrT0kwRoSfSz9KxenkyJoTelA=="],
+    "@tauri-apps/cli-linux-arm64-gnu": ["@tauri-apps/cli-linux-arm64-gnu@2.11.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-N41/ukTRVe6XSuUTESuFdGeOW2i7k62tK+6gHK5Kd5/q5RPvvi19GaWAVPPb9u95HSGmTChSolBfzynUsssFaA=="],
 
-    "@tauri-apps/cli-linux-arm64-musl": ["@tauri-apps/cli-linux-arm64-musl@2.10.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-MIj78PDDGjkg3NqGptDOGgfXks7SYJwhiMh8SBoZS+vfdz7yP5jN18bNaLnDhsVIPARcAhE1TlsZe/8Yxo2zqg=="],
+    "@tauri-apps/cli-linux-arm64-musl": ["@tauri-apps/cli-linux-arm64-musl@2.11.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-v277UnT/fB64xAfSroL5N3Km3tLmvATWqJJw/wRI+g6o+HkeD0slyE7gOhNs1MbjE41R7bQOTxMVoL3aomUJmw=="],
 
-    "@tauri-apps/cli-linux-riscv64-gnu": ["@tauri-apps/cli-linux-riscv64-gnu@2.10.1", "", { "os": "linux", "cpu": "none" }, "sha512-X0lvOVUg8PCVaoEtEAnpxmnkwlE1gcMDTqfhbefICKDnOTJ5Est3qL0SrWxizDackIOKBcvtpejrSiVpuJI1kw=="],
+    "@tauri-apps/cli-linux-riscv64-gnu": ["@tauri-apps/cli-linux-riscv64-gnu@2.11.4", "", { "os": "linux", "cpu": "none" }, "sha512-qqgNkQ2u1yZHxjhxsZaxUtRDW8dIqIYm33rx/mzwQv0SfY9x1B+iraj8vWeFiXjjSVVhEMepXSOts1TqPzvXNQ=="],
 
-    "@tauri-apps/cli-linux-x64-gnu": ["@tauri-apps/cli-linux-x64-gnu@2.10.1", "", { "os": "linux", "cpu": "x64" }, "sha512-2/12bEzsJS9fAKybxgicCDFxYD1WEI9kO+tlDwX5znWG2GwMBaiWcmhGlZ8fi+DMe9CXlcVarMTYc0L3REIRxw=="],
+    "@tauri-apps/cli-linux-x64-gnu": ["@tauri-apps/cli-linux-x64-gnu@2.11.4", "", { "os": "linux", "cpu": "x64" }, "sha512-2VRNWl84FOH0m2giiDkO2h0QXlcMJeX+zJDpI5kDIQAx6s+geF3v48F4DXfJez4GS/FdoDGnPnw1C2iYGbQ7bQ=="],
 
-    "@tauri-apps/cli-linux-x64-musl": ["@tauri-apps/cli-linux-x64-musl@2.10.1", "", { "os": "linux", "cpu": "x64" }, "sha512-Y8J0ZzswPz50UcGOFuXGEMrxbjwKSPgXftx5qnkuMs2rmwQB5ssvLb6tn54wDSYxe7S6vlLob9vt0VKuNOaCIQ=="],
+    "@tauri-apps/cli-linux-x64-musl": ["@tauri-apps/cli-linux-x64-musl@2.11.4", "", { "os": "linux", "cpu": "x64" }, "sha512-o9GyhYor/nc7xarmwDE3ka2szuW3uuZzXjHWh64Q8YX5AtSgxdQkFWzrY4O8KiGtVNvFBI14H3Q49Qj5TOIP/A=="],
 
-    "@tauri-apps/cli-win32-arm64-msvc": ["@tauri-apps/cli-win32-arm64-msvc@2.10.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-iSt5B86jHYAPJa/IlYw++SXtFPGnWtFJriHn7X0NFBVunF6zu9+/zOn8OgqIWSl8RgzhLGXQEEtGBdR4wzpVgg=="],
+    "@tauri-apps/cli-win32-arm64-msvc": ["@tauri-apps/cli-win32-arm64-msvc@2.11.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-ld5Ehb598m0VkYyylRPNeCFsBe/km0jxis6KgMpl3IGY6I/i1RwQXO05I1AsXUXO2WC6AvB/Lw4qTf/asiuEiQ=="],
 
-    "@tauri-apps/cli-win32-ia32-msvc": ["@tauri-apps/cli-win32-ia32-msvc@2.10.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-gXyxgEzsFegmnWywYU5pEBURkcFN/Oo45EAwvZrHMh+zUSEAvO5E8TXsgPADYm31d1u7OQU3O3HsYfVBf2moHw=="],
+    "@tauri-apps/cli-win32-ia32-msvc": ["@tauri-apps/cli-win32-ia32-msvc@2.11.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-12Hxi0XX/H5VFxO/bGgHkFWhml9VMgEOu9CidjeCeTNQ1l6fpUlbiGgSP7CLI3PFtW9/FfbeHieZ+kyWK5H7CA=="],
 
-    "@tauri-apps/cli-win32-x64-msvc": ["@tauri-apps/cli-win32-x64-msvc@2.10.1", "", { "os": "win32", "cpu": "x64" }, "sha512-6Cn7YpPFwzChy0ERz6djKEmUehWrYlM+xTaNzGPgZocw3BD7OfwfWHKVWxXzdjEW2KfKkHddfdxK1XXTYqBRLg=="],
+    "@tauri-apps/cli-win32-x64-msvc": ["@tauri-apps/cli-win32-x64-msvc@2.11.4", "", { "os": "win32", "cpu": "x64" }, "sha512-+vDiqBIU5dMISg/wNvX3sF+ZHfgJGJ5T0AcO+EHNXV9GGAG+P5fzodlDXD3QdKCRgZxMoCm5PPvj3BqLNjBthw=="],
 
     "@tauri-apps/plugin-autostart": ["@tauri-apps/plugin-autostart@2.5.1", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-zS/xx7yzveCcotkA+8TqkI2lysmG2wvQXv2HGAVExITmnFfHAdj1arGsbbfs3o6EktRHf6l34pJxc3YGG2mg7w=="],
+
+    "@tauri-apps/plugin-dialog": ["@tauri-apps/plugin-dialog@2.7.2", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-pX0IGm1I3I6wc+zeKYcq1GSqogK6okCNX5fOdaNU5ab1AjGS6l1E5wFNjEb7meg7ZFSp0JUs+0jQGQNyOvLrsg=="],
 
     "@tauri-apps/plugin-opener": ["@tauri-apps/plugin-opener@2.5.3", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ=="],
 
@@ -267,6 +271,8 @@
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "lucide-react": ["lucide-react@1.34.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-vnjGJNI7Htk5+oWW8gXGuaLgwgAb0T6/iZbBrp9JCfRFwdNWZ0YTm3eyxjOLgwN6r8iyAf3UA70zNmBRBNv7yg=="],
 
     "motion-dom": ["motion-dom@12.38.0", "", { "dependencies": { "motion-utils": "^12.36.0" } }, "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA=="],
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@crabnebula/tauri-plugin-drag": "^2.1.0",
     "@tauri-apps/api": "~2.11.1",
     "@tauri-apps/plugin-autostart": "^2.5.1",
+    "@tauri-apps/plugin-dialog": "^2.7.2",
     "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-updater": "^2.10.1",
     "framer-motion": "^12.38.0",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -419,6 +419,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-autostart",
+ "tauri-plugin-dialog",
  "tauri-plugin-drag",
  "tauri-plugin-opener",
  "tauri-plugin-updater",
@@ -3874,6 +3875,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4783,6 +4808,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2d3c1dbe38037e7f590cdf2492594d5ceebe031e7bc7e827509b22a999d2940"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-drag"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4795,6 +4838,30 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 1.0.7+spec-1.1.0",
+ "url",
 ]
 
 [[package]]
@@ -5145,6 +5212,21 @@ dependencies = [
  "toml_parser",
  "toml_writer",
  "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml"
+version = "1.0.7+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd28d57d8a6f6e458bc0b8784f8fdcc4b99a437936056fa122cb234f18656a96"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde_core",
+ "serde_spanned 1.0.4",
+ "toml_datetime 1.0.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -46,6 +46,7 @@ windows = { version = "0.61", features = [
   "Win32_Graphics_Dwm",
   "Win32_Graphics_Gdi",
   "Win32_System_LibraryLoader",
+  "Win32_System_IO",
   "Win32_Security",
   "Win32_System_Registry",
   "Win32_Devices_FunctionDiscovery",
@@ -60,4 +61,5 @@ wmi = "0.14"
 tokio = { version = "1", features = ["time"] }
 image = "0.25"
 tauri-plugin-drag = "2.1.1"
+tauri-plugin-dialog = "2"
 

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -15,6 +15,7 @@
     "autostart:default",
     "core:app:default",
     "updater:allow-check",
-    "updater:allow-download-and-install"
+    "updater:allow-download-and-install",
+    "dialog:default"
   ]
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1792,3 +1792,183 @@ pub fn get_system_accent_color() -> Result<String, String> {
         }
     }
 }
+
+#[tauri::command]
+pub fn export_settings(app: AppHandle) -> Result<String, String> {
+    let path = app.path().app_config_dir().map_err(|e| e.to_string())?.join("settings.json");
+    if let Ok(content) = std::fs::read_to_string(&path) {
+        // Validate it's valid JSON before returning
+        let _settings: HashMap<String, serde_json::Value> =
+            serde_json::from_str(&content).map_err(|e| format!("Invalid settings file: {}", e))?;
+        Ok(content)
+    } else {
+        Err("No settings file found".into())
+    }
+}
+
+#[tauri::command]
+pub fn read_settings_from_path(path: String) -> Result<String, String> {
+    std::fs::read_to_string(&path).map_err(|e| format!("Failed to read file: {}", e))
+}
+
+#[tauri::command]
+pub fn write_settings_to_path(path: String, content: String) -> Result<(), String> {
+    std::fs::write(&path, content).map_err(|e| format!("Failed to write file: {}", e))
+}
+
+#[tauri::command]
+pub fn import_settings(app: AppHandle, settings: String) -> Result<(), String> {
+    let imported: HashMap<String, serde_json::Value> =
+        serde_json::from_str(&settings).map_err(|e| format!("Invalid JSON: {}", e))?;
+
+    let path = app.path().app_config_dir().map_err(|e| e.to_string())?.join("settings.json");
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+
+    let content = serde_json::to_string_pretty(&imported).map_err(|e| e.to_string())?;
+    std::fs::write(&path, content).map_err(|e| e.to_string())?;
+
+    // Broadcast changes for every imported key so all windows re-sync
+    for (key, value) in &imported {
+        let _ = app.emit("settings-changed", serde_json::json!({ "key": key, "value": value }));
+    }
+
+    // Handle bloom-scale special case
+    if imported.get("bloom-scale").is_some() {
+        if let Some(main_win) = app.get_webview_window("main") {
+            let notch_fixed = imported.get("bloom-notch-mode")
+                .map(|v| v.as_str() == Some("fixed"))
+                .unwrap_or(true);
+            if notch_fixed {
+                crate::services::register_appbar(main_win);
+            }
+        }
+        if let Some(dock_win) = app.get_webview_window("dock") {
+            let is_fixed = imported.get("bloom-dock-mode")
+                .map(|v| v.as_str() == Some("fixed"))
+                .unwrap_or(false);
+            if is_fixed {
+                crate::services::register_dock_appbar(dock_win);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub fn setup_settings_watcher(app: AppHandle) {
+    use tauri::Manager;
+
+    let config_dir = match app.path().app_config_dir() {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+    let settings_path = config_dir.join("settings.json");
+
+    // Read initial state for diffing
+    let initial_state: HashMap<String, serde_json::Value> = std::fs::read_to_string(&settings_path)
+        .ok()
+        .and_then(|c| serde_json::from_str(&c).ok())
+        .unwrap_or_default();
+
+    let initial_state = std::sync::Arc::new(std::sync::Mutex::new(initial_state));
+
+    std::thread::spawn(move || {
+        use windows::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
+        use windows::Win32::Storage::FileSystem::{
+            CreateFileW, FILE_FLAG_BACKUP_SEMANTICS, FILE_LIST_DIRECTORY,
+            FILE_NOTIFY_CHANGE_LAST_WRITE,
+            OPEN_EXISTING, ReadDirectoryChangesW,
+        };
+        use windows::Win32::System::IO::OVERLAPPED;
+        use windows::Win32::System::Threading::{CreateEventW, WaitForSingleObject, INFINITE};
+
+        unsafe {
+            let dir_path: Vec<u16> = config_dir.to_string_lossy()
+                .encode_utf16()
+                .chain(std::iter::once(0))
+                .collect();
+
+            let dir_handle = match CreateFileW(
+                windows::core::PCWSTR(dir_path.as_ptr()),
+                FILE_LIST_DIRECTORY.0,
+                windows::Win32::Storage::FileSystem::FILE_SHARE_READ
+                    | windows::Win32::Storage::FileSystem::FILE_SHARE_WRITE
+                    | windows::Win32::Storage::FileSystem::FILE_SHARE_DELETE,
+                None,
+                OPEN_EXISTING,
+                FILE_FLAG_BACKUP_SEMANTICS,
+                None,
+            ) {
+                Ok(h) if h != INVALID_HANDLE_VALUE => h,
+                _ => return,
+            };
+
+            let h_event = match CreateEventW(None, false, false, None) {
+                Ok(e) => e,
+                Err(_) => {
+                    let _ = CloseHandle(dir_handle);
+                    return;
+                }
+            };
+
+            let mut notify_buffer = [0u8; 4096];
+            let mut bytes_returned = 0u32;
+            let mut overlapped = OVERLAPPED::default();
+            overlapped.hEvent = h_event;
+
+            loop {
+                let success = ReadDirectoryChangesW(
+                    dir_handle,
+                    notify_buffer.as_mut_ptr() as *mut _,
+                    notify_buffer.len() as u32,
+                    false,
+                    FILE_NOTIFY_CHANGE_LAST_WRITE,
+                    Some(&mut bytes_returned),
+                    Some(&mut overlapped),
+                    None,
+                );
+
+                if success.is_err() {
+                    break;
+                }
+
+                WaitForSingleObject(h_event, INFINITE);
+
+                std::thread::sleep(std::time::Duration::from_millis(200));
+
+                if let Ok(new_content) = std::fs::read_to_string(&settings_path) {
+                    if let Ok(new_settings) = serde_json::from_str::<HashMap<String, serde_json::Value>>(&new_content) {
+                        let mut prev = initial_state.lock().unwrap();
+
+                        for (key, value) in &new_settings {
+                            if prev.get(key) != Some(value) {
+                                let _ = app.emit(
+                                    "settings-external-changed",
+                                    serde_json::json!({ "key": key, "value": value }),
+                                );
+                            }
+                        }
+
+                        let removed_keys: Vec<String> = prev.keys()
+                            .filter(|k| !new_settings.contains_key(*k))
+                            .cloned()
+                            .collect();
+                        for key in removed_keys {
+                            let _ = app.emit(
+                                "settings-external-changed",
+                                serde_json::json!({ "key": key, "value": null }),
+                            );
+                        }
+
+                        *prev = new_settings;
+                    }
+                }
+            }
+
+            let _ = CloseHandle(h_event);
+            let _ = CloseHandle(dir_handle);
+        }
+    });
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -63,6 +63,7 @@ fn main() {
     setup_brightness_worker();
     let app = tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_autostart::init(
             tauri_plugin_autostart::MacosLauncher::LaunchAgent,
@@ -128,7 +129,11 @@ fn main() {
             set_brightness,
             get_battery_saver_state,
             open_battery_saver_settings,
-            get_system_accent_color
+            get_system_accent_color,
+            export_settings,
+            import_settings,
+            read_settings_from_path,
+            write_settings_to_path
         ])
         .setup(|app| {
             init_taskbar_marker(app.handle());
@@ -302,6 +307,7 @@ fn main() {
             let _hook = services::setup_keyboard_hook();
             setup_taskbar_hook();
             setup_audio_visualization(app.handle().clone());
+            setup_settings_watcher(app.handle().clone());
 
             // Listen for second-instance signal to open settings
             unsafe {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -668,11 +668,60 @@ function App() {
       setIsEdgeHovered(event.payload);
     });
 
+    const unlistenExternalSettings = listen<{ key: string, value: any }>("settings-external-changed", (event) => {
+      const { key, value } = event.payload;
+      if (value !== null) {
+        localStorage.setItem(key, String(value));
+      } else {
+        localStorage.removeItem(key);
+      }
+      if (key === "bloom-weather-enabled") setSettingsWeatherEnabled(value !== "false");
+      if (key === "bloom-calendar-enabled") setSettingsCalendarEnabled(value !== "false");
+      if (key === "bloom-music-mode-enabled") setSettingsMusicModeEnabled(value !== "false");
+      if (key === "bloom-music-compact-notch") setSettingsMusicCompactNotch(value !== "false");
+      const vizKey = key === "bloom-media-visualizer-enabled" || key === "bloom-visualizer-enabled";
+      if (vizKey) setSettingsVisualizerEnabled(value !== "false");
+      if (key === "bloom-media-album-art-enabled") setSettingsAlbumArtEnabled(value !== "false");
+      if (key === "bloom-media-ambience-enabled") setSettingsAmbienceEnabled(value !== "false");
+      if (key === "bloom-media-compact-glow-enabled") setSettingsCompactGlowEnabled(value !== "false");
+      if (key === "bloom-media-layout") setMediaLayout(value as 'classic' | 'compact');
+      if (key === "bloom-temp-unit") setTempUnit(value as string);
+      if (key === "bloom-corners-enabled") setSettingsCornersEnabled(value === "true");
+      if (key === "bloom-scale") setScale(Number(value));
+      if (key === "bloom-low-battery-threshold") setLowBatteryThreshold(parseInt(value));
+      if (key === "bloom-dock-enabled") {
+        if (windowLabel === 'main') {
+          if (value === "true" || value === true) {
+            invoke("init_dock", { mode: localStorage.getItem("bloom-dock-mode") || "fixed" });
+          } else {
+            invoke("toggle_dock", { enable: false });
+          }
+          setTimeout(() => invoke("sync_appbar"), 200);
+        }
+      }
+      if (key === "bloom-dock-mode") {
+        const mapped = value === "auto-hide" ? "smart" : value;
+        setDockMode(mapped);
+        if (windowLabel === 'main') {
+          invoke("change_dock_mode", { mode: mapped });
+          setTimeout(() => invoke("sync_appbar"), 200);
+        }
+      }
+      if (key === "bloom-notch-mode") {
+        const mapped = value === "auto-hide" ? "smart" : value;
+        setNotchMode(mapped);
+        if (windowLabel === 'main') {
+          invoke("change_notch_mode", { mode: mapped });
+        }
+      }
+    });
+
     return () => {
       unlistenVisibility.then(f => f());
       unlistenSettings.then(f => f());
       unlistenNotchOverlap.then(f => f());
       unlistenNotchEdgeHover.then(f => f());
+      unlistenExternalSettings.then(f => f());
     };
   }, [windowLabel]);
 

--- a/src/Dock.tsx
+++ b/src/Dock.tsx
@@ -204,11 +204,28 @@ const Dock = memo(function Dock() {
       setIsVisible(event.payload);
     });
 
+    const unlistenExternalSettings = listen<{ key: string, value: any }>("settings-external-changed", (event) => {
+      const { key, value } = event.payload;
+      if (value !== null) {
+        localStorage.setItem(key, String(value));
+      } else {
+        localStorage.removeItem(key);
+      }
+      if (key === "bloom-dock-mode") {
+        const mapped = value === "auto-hide" ? "smart" : value;
+        setDockMode(mapped);
+      }
+      if (key === "bloom-dock-preview-enabled") setDockPreviewEnabled(value === "true");
+      if (key === "bloom-dock-icon-only") setDockIconOnly(value === "true");
+      if (key === "bloom-scale") setScale(Number(value));
+    });
+
     return () => {
       unlistenSettings.then(f => f());
       unlistenOverlap.then(f => f());
       unlistenEdgeHover.then(f => f());
       unlistenVisibility.then(f => f());
+      unlistenExternalSettings.then(f => f());
     };
   }, []);
 

--- a/src/Overlay.tsx
+++ b/src/Overlay.tsx
@@ -332,6 +332,24 @@ function OverlayApp() {
       }
     });
 
+    const unlistenExternalSettings = listen<{ key: string, value: any }>("settings-external-changed", (event) => {
+      const { key, value } = event.payload;
+      if (value !== null) {
+        localStorage.setItem(key, String(value));
+      } else {
+        localStorage.removeItem(key);
+      }
+      if (key === "bloom-volume-overlay-enabled") {
+        setVolumeOverlayEnabled(value !== "false");
+      }
+      if (key === "bloom-volume-edge-enabled") setVolumeEdgeEnabled(value !== "false");
+      if (key === "bloom-brightness-overlay-enabled") {
+        setBrightnessOverlayEnabled(value !== "false");
+      }
+      if (key === "bloom-brightness-edge-enabled") setBrightnessEdgeEnabled(value !== "false");
+      if (key === "bloom-scale") setScale(Number(value));
+    });
+
     return () => {
       volPromise.then(fn => fn());
       volEdgePromise.then(fn => fn());
@@ -339,6 +357,7 @@ function OverlayApp() {
       brightEdgePromise.then(fn => fn());
       settingsPromise.then(fn => fn());
       autoUpdatePromise.then(fn => fn());
+      unlistenExternalSettings.then(fn => fn());
       document.removeEventListener('contextmenu', preventContext);
     };
   }, [volumeOverlayEnabled, volumeEdgeEnabled, brightnessOverlayEnabled, brightnessEdgeEnabled, resetHideTimeout]);

--- a/src/Settings.tsx
+++ b/src/Settings.tsx
@@ -5,6 +5,7 @@ import { Effect } from "@tauri-apps/api/window";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { enable, disable, isEnabled } from "@tauri-apps/plugin-autostart";
+import { open as openDialog, save as saveDialog } from "@tauri-apps/plugin-dialog";
 import { check } from "@tauri-apps/plugin-updater";
 import { getVersion } from "@tauri-apps/api/app";
 import {
@@ -38,6 +39,8 @@ import {
   Hexagon,
   Info,
   X,
+  Upload,
+  FileDown,
 } from "lucide-react";
 import "./Settings.css";
 import { initTheme, hexToHsl } from "./theme";
@@ -96,6 +99,8 @@ function SettingsApp() {
   });
 
   const [activeTab, setActiveTab] = useState("general");
+  const [exportStatus, setExportStatus] = useState<"idle" | "exporting" | "success" | "error">("idle");
+  const [importStatus, setImportStatus] = useState<"idle" | "importing" | "success" | "error">("idle");
 
   useEffect(() => {
     invoke('resize_settings_window', {
@@ -252,6 +257,45 @@ function SettingsApp() {
       if (key === "theme-brightness") setThemeBrightness(Number(value));
     });
 
+    // Handle external file changes (from file watcher or other tools editing settings.json)
+    const unlistenExternal = listen<{ key: string, value: any }>("settings-external-changed", (event) => {
+      const { key, value } = event.payload;
+      // Sync localStorage with the externally changed value
+      if (value !== null && value !== undefined) {
+        localStorage.setItem(key, String(value));
+      } else {
+        localStorage.removeItem(key);
+      }
+      // Update local state
+      if (key === "bloom-dock-mode") setDockMode(value === "auto-hide" ? "smart" : value);
+      if (key === "bloom-notch-mode") setNotchMode(value === "auto-hide" ? "smart" : value);
+      if (key === "bloom-dock-enabled") setDockEnabled(value === "true");
+      if (key === "bloom-dock-icon-only") setDockIconOnly(value === "true");
+      if (key === "bloom-weather-enabled") setWeatherEnabled(value === "true");
+      if (key === "bloom-calendar-enabled") setCalendarEnabled(value === "true");
+      if (key === "bloom-music-mode-enabled") setMusicModeEnabled(value === "true");
+      if (key === "bloom-music-compact-notch") setMusicCompactNotch(value === "true");
+      if (key === "bloom-media-ambience-enabled") setMediaAmbienceEnabled(value === "true");
+      if (key === "bloom-media-compact-glow-enabled") setMediaCompactGlowEnabled(value === "true");
+      if (key === "bloom-media-layout") setMediaLayout(value as 'classic' | 'compact');
+      if (key === "bloom-corners-enabled") setCornersEnabled(value === "true");
+      if (key === "bloom-low-battery-threshold") setLowBatteryThreshold(Number(value));
+      if (key === "bloom-scale") setScale(Number(value));
+      if (key === "bloom-theme-mode") setThemeMode(value);
+      if (key === "bloom-theme-color") setThemeColor(value);
+      if (key === "bloom-theme-opacity") setThemeOpacity(Number(value));
+      if (key === "bloom-theme-saturation") setThemeSaturation(Number(value));
+      if (key === "bloom-theme-brightness") setThemeBrightness(Number(value));
+      if (key === "bloom-volume-overlay-enabled") setVolumeOverlayEnabled(value === "true");
+      if (key === "bloom-volume-edge-enabled") setVolumeEdgeEnabled(value === "true");
+      if (key === "bloom-brightness-overlay-enabled") setBrightnessOverlayEnabled(value === "true");
+      if (key === "bloom-brightness-edge-enabled") setBrightnessEdgeEnabled(value === "true");
+      if (key === "bloom-dock-preview-enabled") setDockPreviewEnabled(value === "true");
+      if (key === "bloom-auto-update") setAutoUpdate(value === "true");
+      if (key === "bloom-temp-unit") setTempUnitFahrenheit(value === "fahrenheit");
+      if (key === "bloom-weather-city") setCityName(value || "");
+    });
+
     const unlistenAccent = listen<string>("system-accent-changed", (event) => {
       const mode = localStorage.getItem("bloom-theme-mode") || "dark";
       if (mode === "adaptive") {
@@ -267,6 +311,7 @@ function SettingsApp() {
 
     return () => {
       unlisten.then(fn => fn());
+      unlistenExternal.then(fn => fn());
       unlistenAccent.then(fn => fn());
     };
   }, []);
@@ -315,6 +360,111 @@ function SettingsApp() {
     try {
       await appWindow.hide();
     } catch(e) {
+    }
+  };
+
+  const handleExportSettings = async () => {
+    setExportStatus("exporting");
+    try {
+      const settingsJson = await invoke<string>("export_settings");
+      const filePath = await saveDialog({
+        title: "Export Bloom Settings",
+        defaultPath: "bloom-settings.json",
+        filters: [{ name: "JSON", extensions: ["json"] }],
+      });
+      if (filePath) {
+        await invoke("write_settings_to_path", { path: filePath, content: settingsJson });
+        setExportStatus("success");
+        setTimeout(() => setExportStatus("idle"), 2000);
+      } else {
+        setExportStatus("idle");
+      }
+    } catch (e) {
+      console.error("Export failed:", e);
+      setExportStatus("error");
+      setTimeout(() => setExportStatus("idle"), 3000);
+    }
+  };
+
+  const handleImportSettings = async () => {
+    setImportStatus("importing");
+    try {
+      const filePath = await openDialog({
+        title: "Import Bloom Settings",
+        filters: [{ name: "JSON", extensions: ["json"] }],
+        multiple: false,
+      });
+      if (filePath) {
+        const content = await invoke<string>("read_settings_from_path", { path: filePath as string });
+        await invoke("import_settings", { settings: content });
+        // Re-sync all local state from disk
+        const settings: any = await invoke("load_settings");
+        const getVal = (key: string) => {
+          const val = settings[key];
+          if (val !== undefined && val !== null) return String(val);
+          return localStorage.getItem(key);
+        };
+        const weather = getVal("bloom-weather-enabled");
+        if (weather !== null) setWeatherEnabled(weather === "true");
+        const calendar = getVal("bloom-calendar-enabled");
+        if (calendar !== null) setCalendarEnabled(calendar === "true");
+        const musicEnabled = getVal("bloom-music-mode-enabled");
+        if (musicEnabled !== null) setMusicModeEnabled(musicEnabled === "true");
+        const musicCompact = getVal("bloom-music-compact-notch");
+        if (musicCompact !== null) setMusicCompactNotch(musicCompact === "true");
+        const volume = getVal("bloom-volume-overlay-enabled");
+        if (volume !== null) setVolumeOverlayEnabled(volume === "true");
+        const ambience = getVal("bloom-media-ambience-enabled");
+        if (ambience !== null) setMediaAmbienceEnabled(ambience === "true");
+        const compactGlow = getVal("bloom-media-compact-glow-enabled");
+        if (compactGlow !== null) setMediaCompactGlowEnabled(compactGlow === "true");
+        const corners = getVal("bloom-corners-enabled");
+        if (corners !== null) setCornersEnabled(corners === "true");
+        const tempUnit = getVal("bloom-temp-unit");
+        if (tempUnit !== null) setTempUnitFahrenheit(tempUnit === "fahrenheit");
+        const savedCity = getVal("bloom-weather-city");
+        if (savedCity) setCityName(savedCity);
+        const dock = getVal("bloom-dock-enabled");
+        if (dock !== null) setDockEnabled(dock === "true");
+        const dMode = getVal("bloom-dock-mode");
+        if (dMode) setDockMode(dMode === "auto-hide" ? "smart" : dMode);
+        const threshold = getVal("bloom-low-battery-threshold");
+        if (threshold !== null) setLowBatteryThreshold(parseInt(threshold));
+        const nMode = getVal("bloom-notch-mode");
+        if (nMode) setNotchMode(nMode === "auto-hide" ? "smart" : nMode);
+        const preview = getVal("bloom-dock-preview-enabled");
+        if (preview !== null) setDockPreviewEnabled(preview === "true");
+        const iconOnly = getVal("bloom-dock-icon-only");
+        if (iconOnly !== null) setDockIconOnly(iconOnly === "true");
+        const scaleVal = getVal("bloom-scale");
+        if (scaleVal !== null) setScale(parseFloat(scaleVal));
+        const autoUpdateVal = getVal("bloom-auto-update");
+        if (autoUpdateVal !== null) setAutoUpdate(autoUpdateVal === "true");
+        const tMode = getVal("bloom-theme-mode");
+        if (tMode) setThemeMode(tMode);
+        const tColor = getVal("bloom-theme-color");
+        if (tColor) setThemeColor(tColor);
+        const tOpacity = getVal("bloom-theme-opacity");
+        if (tOpacity) setThemeOpacity(parseFloat(tOpacity));
+        const tSaturation = getVal("bloom-theme-saturation");
+        if (tSaturation) setThemeSaturation(parseFloat(tSaturation));
+        const tBrightness = getVal("bloom-theme-brightness");
+        if (tBrightness) setThemeBrightness(parseFloat(tBrightness));
+        const mediaLayout = getVal("bloom-media-layout");
+        if (mediaLayout) setMediaLayout(mediaLayout as 'classic' | 'compact');
+        const volumeEdge = getVal("bloom-volume-edge-enabled");
+        if (volumeEdge !== null) setVolumeEdgeEnabled(volumeEdge === "true");
+        const brightnessEdge = getVal("bloom-brightness-edge-enabled");
+        if (brightnessEdge !== null) setBrightnessEdgeEnabled(brightnessEdge === "true");
+        setImportStatus("success");
+        setTimeout(() => setImportStatus("idle"), 2000);
+      } else {
+        setImportStatus("idle");
+      }
+    } catch (e) {
+      console.error("Import failed:", e);
+      setImportStatus("error");
+      setTimeout(() => setImportStatus("idle"), 3000);
     }
   };
 
@@ -1125,7 +1275,7 @@ function SettingsApp() {
         <p className="about-version">Version {appVersion}</p>
       </div>
 
-      <div className="setting-group-label" style={{ marginTop: '24px' }}>Software Updates</div>
+      <div className="setting-group-label">Software Updates</div>
       <div className="setting-group">
         <div className="setting-item">
           <div className="setting-icon-bg">
@@ -1159,6 +1309,35 @@ function SettingsApp() {
             <span className="setting-desc">
               {updateStatus === 'available' ? "Click to install and restart" : `Currently running v${appVersion}`}
             </span>
+          </div>
+        </div>
+      </div>
+
+      <div className="setting-group-label" style={{ marginTop: '24px' }}>Data</div>
+      <div className="setting-group">
+        <div className="setting-item action" onClick={handleExportSettings}>
+          <div className="setting-icon-bg">
+            <FileDown size={14} strokeWidth={1.5} />
+          </div>
+          <div className="setting-info">
+            <span className="setting-label">
+              {exportStatus === "exporting" ? "Exporting..." : exportStatus === "success" ? "Exported!" : "Export Settings"}
+            </span>
+            <span className="setting-desc">Save settings to a file</span>
+          </div>
+        </div>
+
+        <div className="setting-divider" />
+
+        <div className="setting-item action" onClick={handleImportSettings}>
+          <div className="setting-icon-bg">
+            <Upload size={14} strokeWidth={1.5} />
+          </div>
+          <div className="setting-info">
+            <span className="setting-label">
+              {importStatus === "importing" ? "Importing..." : importStatus === "success" ? "Imported!" : "Import Settings"}
+            </span>
+            <span className="setting-desc">Load settings from a file</span>
           </div>
         </div>
       </div>

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -290,8 +290,27 @@ export function initTheme() {
     }
   });
 
+  const externalPromise = listen<{ key: string; value: any }>('settings-external-changed', (event) => {
+    const { key, value } = event.payload;
+    if (value !== null) {
+      localStorage.setItem(key, String(value));
+    } else {
+      localStorage.removeItem(key);
+    }
+    const themeKeys = ['bloom-theme-mode', 'bloom-theme-color', 'bloom-theme-opacity', 'bloom-theme-saturation', 'bloom-theme-brightness'];
+    if (themeKeys.includes(key)) {
+      const mode = localStorage.getItem('bloom-theme-mode') || 'dark';
+      const color = localStorage.getItem('bloom-theme-color') || '#007aff';
+      const opacity = parseFloat(localStorage.getItem('bloom-theme-opacity') || '0.80');
+      const saturation = parseFloat(localStorage.getItem('bloom-theme-saturation') || '0.50');
+      const brightness = parseFloat(localStorage.getItem('bloom-theme-brightness') || '0.15');
+      applyTheme(mode, color, opacity, saturation, brightness);
+    }
+  });
+
   return () => {
     settingsPromise.then(f => f());
     accentPromise.then(f => f());
+    externalPromise.then(f => f());
   };
 }


### PR DESCRIPTION
- Add export_settings/import_settings backend commands
- Add ReadDirectoryChangesW-based settings file watcher (zero polling)
- Add tauri-plugin-dialog for native Windows save/open file dialogs
- Add Export/Import UI in Settings > About > Data
- Add settings-external-changed event for all windows to sync on external edits
- Add read_settings_from_path/write_settings_to_path helper commands